### PR TITLE
Add documentation for get_mut and add get_ref

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -32,6 +32,11 @@ impl<R> Deflate64Decoder<R> {
         self.inner
     }
 
+    /// Returns reference to innner BufRead instance
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
     /// Returns mutable reference to innner BufRead instance
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.inner

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -32,6 +32,7 @@ impl<R> Deflate64Decoder<R> {
         self.inner
     }
 
+    /// Returns mutable reference to innner BufRead instance
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.inner
     }


### PR DESCRIPTION
- I added get_ref because in most stream wrapper who has get_mut, there is get_ref.
- Add documentation comment for get_mut